### PR TITLE
Fix 19 aiohttp CVEs via signalwire 2.1.0 pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ pytz>=2024.1
 timezonefinder>=6.5
 requests>=2.3,<3
 requests_cache>=1.2.1,<1.3
-signalwire>=2.1,<3
+aiohttp>=3.13.5
+signalwire==2.1.0
 shapely>=2.0,<3
 responses


### PR DESCRIPTION
## Summary

- Pin `signalwire==2.1.0` (from `>=2.1,<3`) and add explicit `aiohttp>=3.13.5` to fix **19 known CVEs** in aiohttp 3.9.5
- `signalwire==2.1.1` hard-pins `aiohttp==3.9.5`; version 2.1.0 has a loose aiohttp constraint, allowing the upgrade
- Vulnerabilities fixed include request smuggling, DoS via memory exhaustion, credential leakage on redirect, header injection, and more (CVE-2024-52304, CVE-2025-53643, CVE-2025-69223–69230, CVE-2026-22815, CVE-2026-34513–34520, CVE-2026-34525)

## Test plan

- [x] Full test suite passes (191 passed, 12 pre-existing failures unrelated to this change)
- [x] `pip-audit` confirms all 19 aiohttp CVEs resolved
- [x] Remaining vulnerabilities (pytest CVE-2025-71176, PyJWT) are tracked separately

https://claude.ai/code/session_01ARrpZoha12bqeHTnzoZpGA

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARrpZoha12bqeHTnzoZpGA)_