### PR TITLE
Fix 23 CVEs in aiohttp, PyJWT, and pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ pandas>=2.2,<3
 pydantic>=2.9,<3
 pydantic_settings>=2.5,<3
 pyproj>=3.7
-pytest>=8.4,<9
-pytest-asyncio>=0.24,<1
+pytest>=9.0.3,<10
+pytest-asyncio>=1.0,<2
 python-dotenv>=1.0
 pyyaml>=6
 pytz>=2024.1
@@ -16,3 +16,5 @@ requests_cache>=1.2.1,<1.3
 signalwire>=2.1,<3
 shapely>=2.0,<3
 responses
+aiohttp>=3.13.4
+PyJWT>=2.12.0


### PR DESCRIPTION
## Summary

- Add floor pins for `aiohttp>=3.13.4` and `PyJWT>=2.12.0` to override signalwire's vulnerable transitive pins (20 aiohttp CVEs, 2 PyJWT CVEs)
- Bump `pytest` from `>=8.4,<9` to `>=9.0.3,<10` to fix **CVE-2025-71176**
- Bump `pytest-asyncio` from `>=0.24,<1` to `>=1.0,<2` for pytest 9.x compatibility

**Note:** `signalwire==2.1.1` (latest) pins `aiohttp==3.9.5` and `twilio==6.54.0` (which pins `PyJWT==1.7.1`). Since signalwire has no newer release, explicit floor pins in requirements.txt are used to force secure versions. Tested with `--no-deps` install of signalwire — all 180 tests pass with no new failures.

Supersedes #5 (which only covered the pytest CVE).

## Test plan

- [x] `pip-audit` shows 0 application CVEs (only pip tooling CVEs remain)
- [x] Full test suite: 180 passed, same 8 pre-existing failures (shapefile data), 0 new failures
- [x] Verified signalwire/twilio functionality works with upgraded aiohttp and PyJWT

https://claude.ai/code/session_01EbtywQKsro95c177KeUNKy

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbtywQKsro95c177KeUNKy)_