### PR TITLE
Default to wildfires when avalanche reports are out of season.

### DIFF
--- a/app/avalanche/base.py
+++ b/app/avalanche/base.py
@@ -58,6 +58,25 @@ class AvalancheProvider(ABC):
         """
         pass
 
+    def is_out_of_season(self, forecast: Dict[str, Any]) -> bool:
+        """Check whether a returned forecast is an out-of-season report.
+
+        Out-of-season markers (e.g. "Spring Conditions") are configured per
+        provider. A forecast counts as out of season only when every band
+        rating across all days is one of those markers; providers with no
+        configured markers are never out of season.
+        """
+        markers = set(self.config.out_of_season)
+        if not markers:
+            return False
+
+        ratings = [
+            rating
+            for day in forecast.get('forecasts', {}).values()
+            for rating in (day['alpine_rating'], day['treeline_rating'], day['below_treeline_rating'])
+        ]
+        return bool(ratings) and all(rating in markers for rating in ratings)
+
     def distance_from_region(self, coords: tuple) -> Optional[float]:
         """Calculate distance from coordinates to nearest region.
 

--- a/app/avalanche/report.py
+++ b/app/avalanche/report.py
@@ -129,6 +129,23 @@ class AvalancheReport:
             logging.warning(f"Network error checking avalanche data: {e}")
             return False
 
+    def out_of_season(self) -> bool:
+        """Check if the location's forecast is an out-of-season report.
+
+        Kept separate from has_data() so auto-detection can fall back to fire
+        while an explicit avalanche request still returns the report.
+        """
+        if not self.provider:
+            return False
+
+        try:
+            forecast = self.provider.get_forecast(self.coords)
+        except RequestException as e:
+            logging.warning(f"Network error checking avalanche season: {e}")
+            return False
+
+        return bool(forecast) and self.provider.is_out_of_season(forecast)
+
     def get_forecast(self, avalanche_filters: Optional[Dict] = None, format: str = 'abbrev') -> Optional[str]:
         """Get formatted avalanche forecast.
 

--- a/app/avalanche/us_nac.py
+++ b/app/avalanche/us_nac.py
@@ -139,7 +139,9 @@ class NationalAvalancheProvider(AvalancheProvider):
         Returns:
             Normalized forecast dict
         """
-        if not data or 'danger' not in data:
+        # Off-season the NAC API returns a "summary" product with an empty
+        # danger array rather than a forecast; treat that as no data.
+        if not data or not data.get('danger'):
             return None
 
         # Extract timezone from zone info

--- a/app/config.py
+++ b/app/config.py
@@ -75,6 +75,7 @@ class AvalancheProviderConfig(BaseModel):
     api_url: str
     cache_timeout: int = 3600
     language: str = 'en'
+    out_of_season: List[str] = []
 
 
 class AvalancheConfig(BaseModel):

--- a/app/messages.py
+++ b/app/messages.py
@@ -226,10 +226,11 @@ def handle_message(message: str) -> str:
     data_type = parsed_data.get("data_type", "auto")
     avalanche_filters = parsed_data.get("avalanche_filters", {})
 
-    # Auto-detect data type based on availability
+    # Auto-detect data type based on availability. Out-of-season avalanche
+    # reports fall back to fire.
     if data_type == "auto":
         avalanche = AvalancheReport(coords)
-        if avalanche.has_data():
+        if avalanche.has_data() and not avalanche.out_of_season():
             data_type = "avalanche"
         else:
             data_type = "fire"

--- a/config.yaml
+++ b/config.yaml
@@ -114,6 +114,7 @@ avalanche:
       api_url: https://api.avalanche.ca/forecasts/{lang}/products/point
       cache_timeout: 3600
       language: en
+      out_of_season: ["Spring Conditions", "Early Season"]
     NationalAvalancheCenter:
       class: NationalAvalancheProvider
       api_url: https://api.avalanche.org/v2/public/product?type=forecast&center_id={center}&zone_id={zone}

--- a/data/avalanche_terms.yaml
+++ b/data/avalanche_terms.yaml
@@ -26,6 +26,7 @@ default:
     "Moderate": "M"
     "Low": "L"
     "Early Season": "ES"
+    "Spring Conditions": "Spring"
     "No Rating": "N/A"
 
   likelihood:

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,6 +41,32 @@ TREKSAFER_ENV=prod pytest -m smoke -v -s
 - Tests will **pass** if transport works correctly
 - Tests will **fail** if transport errors occur
 
+### Manual CLI testing
+
+`scripts/cli_connect.py` sends an ad-hoc message to a running CLI transport and prints the response. Useful for exercising the full parse → route → format path by hand (no SMS or SignalWire account needed).
+
+Start the app in one terminal:
+
+```bash
+python -m app
+```
+
+Then send messages from another terminal (the message is a required positional argument; quote it if it contains spaces):
+
+```bash
+python scripts/cli_connect.py "(50.0, -122.95)"            # bare coords -> auto-detect (fire vs avalanche)
+python scripts/cli_connect.py "(50.0, -122.95) avalanche"  # force avalanche forecast
+python scripts/cli_connect.py "(54.78, -125.47) fire"      # force fire report
+```
+
+Options: `--host` (default `127.0.0.1`), `--port` (default `8888`), `--timeout` (default `30`), `--append-newline`.
+
+Equivalent one-liner with netcat:
+
+```bash
+echo '(50.0, -122.95)' | nc localhost 8888
+```
+
 ### Other pytest commands
 
 Combine markers and test names as needed:

--- a/tests/test_avalanche.py
+++ b/tests/test_avalanche.py
@@ -161,6 +161,90 @@ class TestAvalancheProviderBase:
         assert caplog.records[0].levelname == 'WARNING'
         assert 'geopandas not available' in caplog.records[0].message
 
+
+def _make_forecast(*days):
+    """Build a normalized forecast dict from (alp, tln, btl) rating tuples."""
+    return {
+        'forecasts': {
+            f'Day{i}': {
+                'alpine_rating': alp,
+                'treeline_rating': tln,
+                'below_treeline_rating': btl,
+            }
+            for i, (alp, tln, btl) in enumerate(days)
+        }
+    }
+
+
+def _stub_provider(out_of_season=None):
+    config = AvalancheProviderConfig(
+        class_name='Stub',
+        api_url='https://api.example.com',
+        out_of_season=out_of_season or [],
+    )
+
+    class StubProvider(AvalancheProvider):
+        def get_forecast(self, coords):
+            return None
+
+        def out_of_range(self, coords):
+            return False
+
+    return StubProvider(config)
+
+
+class TestIsOutOfSeason:
+    """Provider out-of-season detection from configured rating markers."""
+
+    def test_true_when_every_rating_is_a_marker(self):
+        provider = _stub_provider(['Spring Conditions', 'Early Season'])
+        forecast = _make_forecast(
+            ('Spring Conditions', 'Spring Conditions', 'Spring Conditions'),
+            ('Early Season', 'Early Season', 'Early Season'),
+        )
+        assert provider.is_out_of_season(forecast) is True
+
+    def test_false_when_any_rating_is_real(self):
+        provider = _stub_provider(['Spring Conditions'])
+        forecast = _make_forecast(('Spring Conditions', 'Moderate', 'Spring Conditions'))
+        assert provider.is_out_of_season(forecast) is False
+
+    def test_false_when_no_markers_configured(self):
+        # e.g. the US provider, which detects off-season structurally instead
+        provider = _stub_provider([])
+        forecast = _make_forecast(('Spring Conditions',) * 3)
+        assert provider.is_out_of_season(forecast) is False
+
+    def test_false_when_forecast_has_no_days(self):
+        provider = _stub_provider(['Spring Conditions'])
+        assert provider.is_out_of_season({'forecasts': {}}) is False
+
+
+class TestReportOutOfSeason:
+    """AvalancheReport.out_of_season() delegates to the selected provider."""
+
+    def test_false_without_provider(self):
+        report = AvalancheReport((19.4326, -99.1332))  # Mexico, no provider
+        assert report.provider is None
+        assert report.out_of_season() is False
+
+    def test_delegates_to_provider(self):
+        report = AvalancheReport((19.4326, -99.1332))
+        report.provider = Mock()
+        report.provider.get_forecast.return_value = {'forecasts': {'Mon': {}}}
+        report.provider.is_out_of_season.return_value = True
+
+        assert report.out_of_season() is True
+        report.provider.is_out_of_season.assert_called_once()
+
+    def test_false_when_no_forecast_returned(self):
+        report = AvalancheReport((19.4326, -99.1332))
+        report.provider = Mock()
+        report.provider.get_forecast.return_value = None
+
+        assert report.out_of_season() is False
+        report.provider.is_out_of_season.assert_not_called()
+
     def test_calculate_distances_no_gdf(self):
         """Test _calculate_distances with no regions_gdf."""
         config = AvalancheProviderConfig(

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,5 +1,7 @@
 import pytest
-from app.messages import Messages
+from unittest.mock import patch
+
+from app.messages import Messages, handle_message
 
 
 def mock_fire(**overrides):
@@ -159,3 +161,29 @@ class TestDistanceFormatting:
     def test_distance_exactly_10km(self):
         """10000m = 10km (boundary case)."""
         assert Messages()._format_distance(10000) == 10
+
+
+class TestAutoDetectRouting:
+    """Bare coordinates auto-detect between avalanche and fire."""
+
+    @patch("app.messages.handle_fire_request", return_value="FIRE")
+    @patch("app.messages.handle_avalanche_request", return_value="AVY")
+    @patch("app.messages.AvalancheReport")
+    def test_out_of_season_routes_to_fire(self, mock_report_cls, mock_avy, mock_fire):
+        report = mock_report_cls.return_value
+        report.has_data.return_value = True
+        report.out_of_season.return_value = True
+
+        assert handle_message("(50.12,-122.90)") == "FIRE"
+        mock_avy.assert_not_called()
+
+    @patch("app.messages.handle_fire_request", return_value="FIRE")
+    @patch("app.messages.handle_avalanche_request", return_value="AVY")
+    @patch("app.messages.AvalancheReport")
+    def test_in_season_routes_to_avalanche(self, mock_report_cls, mock_avy, mock_fire):
+        report = mock_report_cls.return_value
+        report.has_data.return_value = True
+        report.out_of_season.return_value = False
+
+        assert handle_message("(50.12,-122.90)") == "AVY"
+        mock_fire.assert_not_called()

--- a/tests/test_us_avalanche.py
+++ b/tests/test_us_avalanche.py
@@ -237,6 +237,27 @@ class TestNACAPIIntegration:
         assert day2['treeline_rating'] == 'Low'
         assert day2['below_treeline_rating'] == 'Low'
 
+    def test_off_season_summary_returns_none(self, nac_config):
+        """Off-season the API returns a 'summary' product with empty danger."""
+        provider = NationalAvalancheProvider(nac_config)
+
+        zone_info = {
+            'id': 2815,
+            'center_id': 'CNFAIC',
+            'timezone': 'America/Anchorage',
+            'name': 'Turnagain Pass and Girdwood'
+        }
+
+        off_season = {
+            'product_type': 'summary',
+            'danger': [],
+            'published_time': '2026-04-13T14:00:00+00:00',
+            'forecast_avalanche_problems': [],
+            'forecast_zone': [{}],
+        }
+
+        assert provider._parse_forecast(off_season, zone_info) is None
+
 
 class TestNACEdgeCases:
     """Test NAC edge cases and error conditions."""
@@ -277,7 +298,7 @@ class TestNACEdgeCases:
         assert any('Invalid NAC problem location' in record.message for record in caplog.records)
 
     def test_empty_danger_ratings(self, nac_config, caplog):
-        """Test empty danger array handling."""
+        """Empty danger array (off-season summary) yields no forecast."""
         provider = NationalAvalancheProvider(nac_config)
 
         zone_info = {
@@ -294,11 +315,7 @@ class TestNACEdgeCases:
             'forecast_zone': [{'url': 'https://example.com'}]
         }
 
-        result = provider._parse_forecast(response, zone_info)
-
-        # Should still parse but with empty forecasts
-        assert result is not None
-        assert len(result['forecasts']) == 0
+        assert provider._parse_forecast(response, zone_info) is None
 
     def test_missing_forecast_zone(self, nac_config):
         """Test missing forecast_zone in response."""


### PR DESCRIPTION
When a message contains only coordinates (no fire/avalanche keyword), auto-detection no longer returns stale off-season avalanche data. Off-season locations now fall back to fire reports.